### PR TITLE
Read Endurain port from environment

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,7 +81,6 @@ def create_app() -> FastAPI:
     # Add CORS middleware to allow requests from the frontend
     origins = [
         "http://localhost",
-        "http://localhost:8080",
         "http://localhost:5173",
         os.environ.get("ENDURAIN_HOST"),
     ]

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -14,6 +14,7 @@ services:
       #- STRAVA_AUTH_CODE=changeme
       - GEOCODES_MAPS_API=changeme
       - ENDURAIN_HOST=http://localhost:8080 # host or local ip (example: http://192.168.1.10:8080 or https://endurain.com), default is http://localhost:8080
+      - ENDURAIN_PORT=8080
       - BEHIND_PROXY=false # default value is false. Change to true if behind reverse proxy
     volumes:
     #  - <local_path>/endurain/backend/app:/app # Configure volume if you want to edit the code locally by cloning the repo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,7 @@ ENV UID=1000 \
     JAEGER_PROTOCOL="http" \
     JAGGER_PORT=4317 \
     ENDURAIN_HOST="http://localhost:8080" \
+    ENDURAIN_PORT=8080 \
     GEOCODES_MAPS_API="changeme" \
     BEHIND_PROXY=false
 
@@ -90,11 +91,11 @@ RUN chown -R $UID:$GID /app
 # Switch to the non-root user by UID and GID
 USER $UID:$GID
 
-# Make port 8080 available to the world outside this container
-EXPOSE 8080
+# Make port available to the world outside this container
+EXPOSE ${ENDURAIN_PORT}
 
 # Add a healthcheck
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s CMD curl -f http://localhost:8080/api/v1/about || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s CMD curl -f "$ENDURAIN_HOST/api/v1/about" || exit 1
 
 # Run the FastAPI app
 ENTRYPOINT ["/docker-entrypoint.d/start.sh"]

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -45,7 +45,7 @@ fi
 echo "Starting FastAPI with BEHIND_PROXY=$BEHIND_PROXY"
 
 # Define the base command for starting the FastAPI server as an array
-CMD=("uvicorn" "main:app" "--host" "0.0.0.0" "--port" "8080")
+CMD=("uvicorn" "main:app" "--host" "0.0.0.0" "--port" "${ENDURAIN_PORT:-8080}")
 
 # Add --proxy-headers if BEHIND_PROXY is true
 if [ "$BEHIND_PROXY" = "true" ]; then

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,7 @@ Environment variable  | Default value | Optional | Notes |
 | GID | 1000 | Yes | Group ID for mounted volumes. Default is 1000 |
 | TZ | UTC | Yes | Timezone definition. Useful for TZ calculation for activities that do not have coordinates associated, like indoor swim or weight training. If not specified UTC will be used. List of available time zones [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). Format `Europe/Lisbon` expected |
 | ENDURAIN_HOST | http://localhost:8080 | `No` | Required for internal communication and Strava. For Strava https must be used. Host or local ip (example: http://192.168.1.10:8080 or https://endurain.com) |
+| ENDURAIN_PORT | 8080 | `No` | Main application port |
 | GEOCODES_MAPS_API | changeme | `No` | <a href="https://geocode.maps.co/">Geocode maps</a> offers a free plan consisting of 1 Request/Second. Registration necessary. |
 | DB_TYPE | postgres | Yes | mariadb or postgres |
 | DB_HOST | postgres | Yes | mariadb or postgres |


### PR DESCRIPTION
Tiny PR to read the port from an environment variable. Potentially useful if someone runs this either without Docker, or in a network space where 8080 is taken up by another service. Closes #63.