### PR TITLE
add healthcheck for postgres

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -24,7 +24,8 @@ services:
     ports:
       - "8080:8080" # Endurain port, change per your needs
     depends_on:
-      - postgres # mariadb or postgres
+      - postgres: # mariadb or postgres
+        condition: service_healthy # remove this line when using mariadb
       - jaeger # optional
     restart: unless-stopped
   
@@ -54,6 +55,11 @@ services:
       - PGDATA=/var/lib/postgresql/data/pgdata
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U endurain"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     volumes:
       - <local_path>/postgres:/var/lib/postgresql/data
     restart: unless-stopped


### PR DESCRIPTION
Endurain ran into errors when starting the docker container.
By adding a healthcheck, the application waits for the database to start. This solves the error.


```
2025-02-14 17:17:35 endurain  | sqlalchemy.exc.OperationalError: (psycopg.OperationalError) connection failed: connection to server at "172.22.0.2", port 5432 failed: Connection refused
2025-02-14 17:17:35 endurain  |         Is the server running on that host and accepting TCP/IP connections?
2025-02-14 17:17:35 endurain  | (Background on this error at: https://sqlalche.me/e/20/e3q8)
2025-02-14 17:17:35 endurain  | 
2025-02-14 17:17:35 endurain  | ERROR:    Application startup failed. Exiting.
```