### PR TITLE
import garmin data in date range

### DIFF
--- a/backend/app/garmin/activity_utils.py
+++ b/backend/app/garmin/activity_utils.py
@@ -17,194 +17,148 @@ import users.crud as users_crud
 
 from core.database import SessionLocal
 
-
-def fetch_and_process_activities(
+def fetch_and_process_activities_by_dates(
     garminconnect_client: garminconnect.Garmin,
     start_date: datetime,
+    end_date: datetime,
     user_id: int,
     db: Session,
 ) -> list[activities_schema.Activity] | None:
-    # Fetch Garmin Connect activities after the specified start date
     try:
         garmin_activities = garminconnect_client.get_activities_by_date(
-            start_date, date.today()
+            start_date.date(), end_date.date()
         )
     except Exception as err:
         core_logger.print_to_log(
-            f"Error fetching activities for user {user_id} after {start_date}: {err}",
+            f"Error fetching activities for user {user_id} between {start_date.date()} and {end_date.date()}: {err}",
             "error",
             exc=err,
         )
         return None
 
     if garmin_activities is None:
-        # Log an informational event if no activities were found
         core_logger.print_to_log_and_console(
-            f"User {user_id}: No new Garmin Connect activities found after {start_date}: garmin_activities is None"
+            f"User {user_id}: No new Garmin Connect activities found between {start_date.date()} and {end_date.date()}: garmin_activities is None"
         )
-
-        # Return 0 to indicate no activities were processed
         return None
 
     parsed_activities = []
 
-    # Download activities
     for activity in garmin_activities:
-        # Get the activity ID
         activity_id = activity["activityId"]
-
-        # Check if the activity is already stored in the database
         activity_db = activities_crud.get_activity_by_garminconnect_id_from_user_id(
             activity_id, user_id, db
         )
 
         if activity_db:
-            # Log an informational event if the activity is already stored
             core_logger.print_to_log(
                 f"User {user_id}: Activity {activity_id} already stored in the database"
             )
             continue
 
         core_logger.print_to_log(f"User {user_id}: Processing activity {activity_id}")
-
-        # Get activity gear
         activity_gear = garminconnect_client.get_activity_gear(activity_id)
-
-        # Download the activity in original format (.zip file)
         zip_data = garminconnect_client.download_activity(
             activity_id, dl_fmt=garminconnect_client.ActivityDownloadFormat.ORIGINAL
         )
-        # Save the zip file
         output_file = f"files/{str(activity_id)}.zip"
-
-        # Write the ZIP data to the output file
         with open(output_file, "wb") as fb:
             fb.write(zip_data)
 
-        # Array to store the names of extracted files
         extracted_files = []
-
-        # Open the ZIP file
         with zipfile.ZipFile(output_file, "r") as zip_ref:
-            # Extract all contents to the specified directory
             zip_ref.extractall("files")
-            # Populate the array with file names
             extracted_files = zip_ref.namelist()
 
         try:
             os.remove(output_file)
         except OSError as err:
             core_logger.print_to_log(
-                f"Error removing file {output_file}: {err}",
-                "error",
-                exc=err,
+                f"Error removing file {output_file}: {err}", "error", exc=err
             )
 
-        for file in extracted_files:
-            # Parse and store the activity from the extracted file
+        for file_path_suffix in extracted_files:
+            full_file_path = os.path.join("files", file_path_suffix) # Ensure correct path construction
             parsed_activities.extend(
                 activities_utils.parse_and_store_activity_from_file(
-                    user_id, f"files/{file}", db, True, activity_gear
+                    user_id, full_file_path, db, True, activity_gear # Pass full_file_path
                 )
                 or []
             )
-
-    # Return the number of activities processed
     return parsed_activities if parsed_activities else None
 
 
 def retrieve_garminconnect_users_activities_for_days(days: int):
     db = SessionLocal()
     try:
-        # Get all users
         users = users_crud.get_all_users(db)
+        calculated_start_date = datetime.now(timezone.utc) - timedelta(days=days)
+        calculated_end_date = datetime.now(timezone.utc)
 
-        # Calculate the start date for the activities
-        start_date = datetime.now(timezone.utc) - timedelta(days=days)
-
-        # Process the activities for each user
         for user in users:
             try:
-                get_user_garminconnect_activities_by_days(
-                    start_date,
+                get_user_garminconnect_activities_by_dates(
+                    calculated_start_date,
+                    calculated_end_date,
                     user.id,
                     db,
                 )
             except Exception as err:
-                # Log specific errors for each user
                 core_logger.print_to_log(
                     f"Error processing activities for user {user.id} in retrieve_garminconnect_users_activities_for_days: {err}",
                     "error",
                     exc=err,
                 )
     except Exception as err:
-        # Log errors that occur during the overall process
         core_logger.print_to_log(
             f"Error in retrieve_garminconnect_users_activities_for_days: {err}",
             "error",
             exc=err,
         )
     finally:
-        # Ensure the session is closed after use
         db.close()
-
 
 def get_user_garminconnect_client(user_id: int, db: Session):
     try:
-        # Get the user integrations by user ID
         user_integrations = garmin_utils.fetch_user_integrations_and_validate_token(
             user_id, db
         )
-
         if user_integrations is None:
             core_logger.print_to_log(f"User {user_id}: Garmin Connect not linked")
             return None
-
-        # Create a Garmin Connect client with the user's access token
         garminconnect_client = garmin_utils.login_garminconnect_using_tokens(
             user_integrations.garminconnect_oauth1,
             user_integrations.garminconnect_oauth2,
         )
-
-        # return the Garmin Connect client
         return garminconnect_client
     except Exception as err:
-        # Log specific errors during getting the Garmin Connect client
         core_logger.print_to_log(
-            f"Error in get_user_garminconnect_client: {err}",
-            "error",
-            exc=err,
+            f"Error in get_user_garminconnect_client: {err}", "error", exc=err
         )
+        return None
 
-
-def get_user_garminconnect_activities_by_days(
-    start_date: datetime, user_id: int, db: Session
+def get_user_garminconnect_activities_by_dates(
+    start_date: datetime, end_date: datetime, user_id: int, db: Session # Added end_date
 ) -> list[activities_schema.Activity] | None:
     try:
-        # Get the Garmin Connect client for the user
         garminconnect_client = get_user_garminconnect_client(user_id, db)
-
         if garminconnect_client is not None:
-            # Fetch Garmin Connect activities after the specified start date
-            garminconnect_activities_processed = fetch_and_process_activities(
-                garminconnect_client, start_date, user_id, db
+            garminconnect_activities_processed = fetch_and_process_activities_by_dates(
+                garminconnect_client, start_date, end_date, user_id, db
             )
-
-            # Log the start of the activities processing
             core_logger.print_to_log(
-                f"User {user_id}: Started Garmin Connect activities processing"
+                f"User {user_id}: Started Garmin Connect activities processing for date range {start_date.date()} to {end_date.date()}"
             )
-
-            # Log an informational event for tracing
+            count = len(garminconnect_activities_processed) if garminconnect_activities_processed else 0
             core_logger.print_to_log(
-                f"User {user_id}: {len(garminconnect_activities_processed) if garminconnect_activities_processed else 0} Garmin Connect activities processed"
+                f"User {user_id}: {count} Garmin Connect activities processed"
             )
-
             return garminconnect_activities_processed
+        return None
     except Exception as err:
-        # Log specific errors during Garmin Connect processing
         core_logger.print_to_log(
-            f"Error in get_user_garminconnect_activities_by_days: {err}",
+            f"Error in get_user_garminconnect_activities_by_dates: {err}",
             "error",
             exc=err,
         )
+        return None

--- a/backend/app/garmin/health_utils.py
+++ b/backend/app/garmin/health_utils.py
@@ -16,26 +16,30 @@ import users.crud as users_crud
 
 from core.database import SessionLocal
 
-
-def fetch_and_process_bc(
+def fetch_and_process_bc_by_dates(
     garminconnect_client: garminconnect.Garmin,
     start_date: datetime,
+    end_date: datetime,
     user_id: int,
     db: Session,
 ) -> int:
-    # Fetch Garmin Connect body composition after the specified start date
-    garmin_bc = garminconnect_client.get_body_composition(start_date, date.today())
-
-    if garmin_bc is None:
-        # Log an informational event if no body composition were found
-        core_logger.print_to_log_and_console(
-            f"User {user_id}: No new Garmin Connect body composition found after {start_date}: garmin_bc is None"
+    try:
+        garmin_bc = garminconnect_client.get_body_composition(start_date.date(), end_date.date())
+    except Exception as err:
+        core_logger.print_to_log(
+            f"Error fetching body composition for user {user_id} between {start_date.date()} and {end_date.date()}: {err}",
+            "error",
+            exc=err,
         )
+        return 0 # Return 0 on error
 
-        # Return 0 to indicate no body composition were processed
+    if garmin_bc is None or "dateWeightList" not in garmin_bc or not garmin_bc["dateWeightList"]:
+        core_logger.print_to_log_and_console(
+            f"User {user_id}: No new Garmin Connect body composition found between {start_date.date()} and {end_date.date()}: garmin_bc is None or empty"
+        )
         return 0
 
-    # Process body composition
+    count_processed = 0
     for bc in garmin_bc["dateWeightList"]:
         health_data = health_data_schema.HealthData(
             user_id=user_id,
@@ -52,7 +56,6 @@ def fetch_and_process_bc(
             garminconnect_body_composition_id=str(bc["samplePk"]),
         )
 
-        # Check if the body composition is already stored in the database
         health_data_db = health_data_crud.get_health_data_by_date(
             user_id, health_data.date, db
         )
@@ -68,36 +71,43 @@ def fetch_and_process_bc(
             core_logger.print_to_log(
                 f"User {user_id}: Body composition created for date {health_data.date}"
             )
-
-    # Return the number of body compositions processed
-    return len(garmin_bc["dateWeightList"])
-
+        count_processed +=1
+    return count_processed
 
 def retrieve_garminconnect_users_bc_for_days(days: int):
-    # Create a new database session
-    db = SessionLocal()
-
+    db = SessionLocal() # This function manages its own session for the loop
     try:
-        # Get all users
         users = users_crud.get_all_users(db)
+        calculated_start_date = datetime.now(timezone.utc) - timedelta(days=days)
+        calculated_end_date = datetime.now(timezone.utc)
+
+        for user in users:
+            try:
+                get_user_garminconnect_bc_by_dates(
+                    calculated_start_date,
+                    calculated_end_date,
+                    user.id,
+                )
+            except Exception as err:
+                core_logger.print_to_log(
+                    f"Error processing body composition for user {user.id} in retrieve_garminconnect_users_bc_for_days: {err}",
+                    "error",
+                    exc=err,
+                )
+    except Exception as err:
+        core_logger.print_to_log(
+            f"Error in retrieve_garminconnect_users_bc_for_days: {err}",
+            "error",
+            exc=err,
+        )
     finally:
-        # Ensure the session is closed after use
         db.close()
 
-    # Process the body composition for each user
-    for user in users:
-        get_user_garminconnect_bc_by_days(
-            (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%S"),
-            user.id,
-        )
-
-
-def get_user_garminconnect_bc_by_days(start_date: datetime, user_id: int):
-    # Create a new database session
+def get_user_garminconnect_bc_by_dates(
+    start_date: datetime, end_date: datetime, user_id: int
+):
     db = SessionLocal()
-
     try:
-        # Get the user integrations by user ID
         user_integrations = garmin_utils.fetch_user_integrations_and_validate_token(
             user_id, db
         )
@@ -106,26 +116,27 @@ def get_user_garminconnect_bc_by_days(start_date: datetime, user_id: int):
             core_logger.print_to_log(f"User {user_id}: Garmin Connect not linked")
             return None
 
-        # Log the start of the body composition processing
         core_logger.print_to_log(
-            f"User {user_id}: Started Garmin Connect body composition processing"
+            f"User {user_id}: Started Garmin Connect body composition processing for date range {start_date.date()} to {end_date.date()}"
         )
 
-        # Create a Garmin Connect client with the user's access token
         garminconnect_client = garmin_utils.login_garminconnect_using_tokens(
             user_integrations.garminconnect_oauth1,
             user_integrations.garminconnect_oauth2,
         )
 
-        # Fetch Garmin Connect body composition after the specified start date
-        num_garminconnect_bc_processed = fetch_and_process_bc(
-            garminconnect_client, start_date, user_id, db
+        num_garminconnect_bc_processed = fetch_and_process_bc_by_dates(
+            garminconnect_client, start_date, end_date, user_id, db
         )
 
-        # Log an informational event for tracing
         core_logger.print_to_log(
             f"User {user_id}: {num_garminconnect_bc_processed} Garmin Connect body composition processed"
         )
+    except Exception as err:
+        core_logger.print_to_log(
+            f"Error in get_user_garminconnect_bc_by_dates: {err}",
+            "error",
+            exc=err,
+        )
     finally:
-        # Ensure the session is closed after use
         db.close()

--- a/frontend/app/src/components/Modals/ModalComponentDateRangeInput.vue
+++ b/frontend/app/src/components/Modals/ModalComponentDateRangeInput.vue
@@ -1,0 +1,128 @@
+<template>
+  <div
+    class="modal fade"
+    :id="modalId"
+    tabindex="-1"
+    :aria-labelledby="`${modalId}Label`"
+    aria-hidden="true"
+  >
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" :id="`${modalId}Label`">{{ title }}</h5>
+          <button
+            type="button"
+            class="btn-close"
+            data-bs-dismiss="modal"
+            aria-label="Close"
+          ></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label :for="`${modalId}StartDate`" class="form-label">{{ $t("generalItems.startDateLabel") }}</label>
+            <input
+              type="date"
+              class="form-control"
+              :id="`${modalId}StartDate`"
+              v-model="startDate"
+            />
+          </div>
+          <div class="mb-3">
+            <label :for="`${modalId}EndDate`" class="form-label">{{ $t("generalItems.endDateLabel") }}</label>
+            <input
+              type="date"
+              class="form-control"
+              :id="`${modalId}EndDate`"
+              v-model="endDate"
+            />
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-bs-dismiss="modal"
+          >
+            {{ $t("generalItems.buttonClose") }}
+          </button>
+          <button
+            type="button"
+            :class="`btn btn-${actionButtonType}`"
+            @click="emitDates"
+            data-bs-dismiss="modal"
+          >
+            {{ actionButtonText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
+
+export default {
+  props: {
+    modalId: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    actionButtonType: {
+      type: String,
+      default: "primary",
+    },
+    actionButtonText: {
+      type: String,
+      required: true,
+    },
+  },
+  emits: ["datesToEmitAction"],
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    const startDate = ref("");
+    const endDate = ref("");
+
+    const setDefaultDates = () => {
+      const today = new Date();
+      const sevenDaysAgo = new Date(today);
+      sevenDaysAgo.setDate(today.getDate() - 7);
+
+      // Format to YYYY-MM-DD
+      startDate.value = sevenDaysAgo.toISOString().split("T")[0];
+      endDate.value = today.toISOString().split("T")[0];
+    };
+
+    onMounted(() => {
+      setDefaultDates();
+      // Listener to reset dates when modal is shown
+      const modalElement = document.getElementById(props.modalId);
+      if (modalElement) {
+        modalElement.addEventListener('show.bs.modal', setDefaultDates);
+      }
+    });
+    
+    // It might be good to also remove the event listener when the component is unmounted,
+    // but for simplicity in this context, we'll omit that.
+
+    function emitDates() {
+      emit("datesToEmitAction", {
+        startDate: startDate.value,
+        endDate: endDate.value,
+      });
+    }
+
+    return {
+      t,
+      startDate,
+      endDate,
+      emitDates,
+    };
+  },
+};
+</script>

--- a/frontend/app/src/components/Settings/SettingsIntegrationsZone.vue
+++ b/frontend/app/src/components/Settings/SettingsIntegrationsZone.vue
@@ -83,21 +83,21 @@
 							<button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
 								{{ $t("settingsIntegrationsZone.buttonDropdownOptions") }}
 							</button>
-							<ul class="dropdown-menu">
-								<li>
-									<!-- retrieve garmin connect activities by days -->
-									<a class="dropdown-item" href="#" role="button" data-bs-toggle="modal" data-bs-target="#retrieveGarminConnectActivitiesByDaysModal">{{ $t("settingsIntegrationsZone.modalRetrieveActivitiesByDaysTitle") }}</a>
-								</li>
-								<li>
-									<!-- retrieve gear -->
-									<a href="#" class="dropdown-item" @click="submitRetrieveGarminConnectGear">{{ $t("settingsIntegrationsZone.buttonRetrieveGear") }}</a>
-								</li>
-								<li>
-									<!-- retrieve garmin connect health data by days -->
-									<a class="dropdown-item" href="#" role="button" data-bs-toggle="modal" data-bs-target="#retrieveGarminConnectHealthDataByDaysModal">{{ $t("settingsIntegrationsZone.modalRetrieveHealthDataByDaysTitle") }}</a>
-								</li>
-								<li><hr class="dropdown-divider"></li>
-								<li>
+<ul class="dropdown-menu">
+<li>
+<!-- retrieve garmin connect activities by date range -->
+<a class="dropdown-item" href="#" role="button" data-bs-toggle="modal" data-bs-target="#retrieveGarminConnectActivitiesByDateRangeModal">{{ $t("settingsIntegrationsZone.modalRetrieveActivitiesByDateRangeTitle") }}</a>
+</li>
+<li>
+<!-- retrieve gear -->
+<a href="#" class="dropdown-item" @click="submitRetrieveGarminConnectGear">{{ $t("settingsIntegrationsZone.buttonRetrieveGear") }}</a>
+</li>
+<li>
+<!-- retrieve garmin connect health data by date range -->
+<a class="dropdown-item" href="#" role="button" data-bs-toggle="modal" data-bs-target="#retrieveGarminConnectHealthDataByDateRangeModal">{{ $t("settingsIntegrationsZone.modalRetrieveHealthDataByDateRangeTitle") }}</a>
+</li>
+<li><hr class="dropdown-divider"></li>
+<li>
 									<!-- unlink Garmin Connect -->
 									<a href="#" class="dropdown-item" role="button" data-bs-toggle="modal" data-bs-target="#unlinkGarminConnectModal">{{ $t("settingsIntegrationsZone.buttonUnlink") }}</a>
 								</li>
@@ -116,18 +116,18 @@
 			<!-- modal unlink Strava -->
 			<ModalComponent modalId="unlinkStravaModal" :title="t('settingsIntegrationsZone.modalUnlinkStravaTitle')" :body="`${t('settingsIntegrationsZone.modalUnlinkStravaBody')}`" :actionButtonType="`danger`" :actionButtonText="t('settingsIntegrationsZone.modalUnlinkStravaTitle')" @submitAction="buttonStravaUnlink"/>
 
-			<!-- modal garmin connect auth -->
-			<GarminConnectLoginModalComponent />
+<!-- modal garmin connect auth -->
+<GarminConnectLoginModalComponent />
 
-			<!-- modal retrieve Garmin Connect activities by days -->
-			<ModalComponentNumberInput modalId="retrieveGarminConnectActivitiesByDaysModal" :title="t('settingsIntegrationsZone.modalRetrieveActivitiesByDaysTitle')" :numberFieldLabel="`${t('settingsIntegrationsZone.modalRetrieveActivitiesByDaysLabel')}`" :actionButtonType="`success`" :actionButtonText="t('settingsIntegrationsZone.modalRetrieveButton')" @numberToEmitAction="submitRetrieveGarminConnectActivities"/>
+<!-- modal retrieve Garmin Connect activities by date range -->
+<ModalComponentDateRangeInput modalId="retrieveGarminConnectActivitiesByDateRangeModal" :title="t('settingsIntegrationsZone.modalRetrieveActivitiesByDateRangeTitle')" :actionButtonType="`success`" :actionButtonText="t('settingsIntegrationsZone.modalRetrieveButton')" @datesToEmitAction="submitRetrieveGarminConnectActivities"/>
 
-			<!-- modal retrieve Garmin Connect health data by days -->
-			<ModalComponentNumberInput modalId="retrieveGarminConnectHealthDataByDaysModal" :title="t('settingsIntegrationsZone.modalRetrieveHealthDataByDaysTitle')" :numberFieldLabel="`${t('settingsIntegrationsZone.modalRetrieveActivitiesByDaysLabel')}`" :actionButtonType="`success`" :actionButtonText="t('settingsIntegrationsZone.modalRetrieveButton')" @numberToEmitAction="submitRetrieveGarminConnectHealthData"/>
+<!-- modal retrieve Garmin Connect health data by date range -->
+<ModalComponentDateRangeInput modalId="retrieveGarminConnectHealthDataByDateRangeModal" :title="t('settingsIntegrationsZone.modalRetrieveHealthDataByDateRangeTitle')" :actionButtonType="`success`" :actionButtonText="t('settingsIntegrationsZone.modalRetrieveButton')" @datesToEmitAction="submitRetrieveGarminConnectHealthData"/>
 
-			<!-- modal unlink Garmin Connect -->
-			<ModalComponent modalId="unlinkGarminConnectModal" :title="t('settingsIntegrationsZone.modalUnlinkGarminConnectTitle')" :body="`${t('settingsIntegrationsZone.modalUnlinkGarminConnectBody')}`" :actionButtonType="`danger`" :actionButtonText="t('settingsIntegrationsZone.modalUnlinkGarminConnectTitle')" @submitAction="buttonGarminConnectUnlink"/>
-		</div>
+<!-- modal unlink Garmin Connect -->
+<ModalComponent modalId="unlinkGarminConnectModal" :title="t('settingsIntegrationsZone.modalUnlinkGarminConnectTitle')" :body="`${t('settingsIntegrationsZone.modalUnlinkGarminConnectBody')}`" :actionButtonType="`danger`" :actionButtonText="t('settingsIntegrationsZone.modalUnlinkGarminConnectTitle')" @submitAction="buttonGarminConnectUnlink"/>
+</div>
 	</div>
 </template>
 
@@ -146,18 +146,20 @@ import { garminConnect } from "@/services/garminConnectService";
 import ModalComponent from "@/components/Modals/ModalComponent.vue";
 import ModalComponentNumberAndStringInput from "@/components/Modals/ModalComponentNumberAndStringInput.vue";
 import ModalComponentNumberInput from "@/components/Modals/ModalComponentNumberInput.vue";
+import ModalComponentDateRangeInput from "@/components/Modals/ModalComponentDateRangeInput.vue"; // Added import
 import GarminConnectLoginModalComponent from "./SettingsIntegrations/GarminConnectLoginModalComponent.vue";
 
 //import Modal from 'bootstrap/js/dist/modal';
 
 export default {
-	components: {
-		ModalComponent,
-		ModalComponentNumberAndStringInput,
-		ModalComponentNumberInput,
-		GarminConnectLoginModalComponent,
-	},
-	setup() {
+components: {
+ModalComponent,
+ModalComponentNumberAndStringInput,
+ModalComponentNumberInput,
+ModalComponentDateRangeInput, // Registered component
+GarminConnectLoginModalComponent,
+},
+setup() {
 		const authStore = useAuthStore();
 		const { locale, t } = useI18n();
 
@@ -261,15 +263,16 @@ export default {
 				push.error(
 					`${t("settingsIntegrationsZone.errorMessageUnableToImportActivities")} - ${error}`,
 				);
-			}
-		}
+}
+}
 
-		async function submitRetrieveGarminConnectActivities(daysToRetrieveGarmin) {
-			try {
-				await garminConnect.getGarminConnectActivitiesLastDays(daysToRetrieveGarmin);
+async function submitRetrieveGarminConnectActivities(dateRange) { // Parameter changed from daysToRetrieveGarmin to dateRange
+try {
+// Call the updated service method with startDate and endDate
+await garminConnect.getGarminConnectActivitiesByDates(dateRange.startDate, dateRange.endDate);
 
-				// Show the loading alert.
-				push.info(
+// Show the loading alert.
+push.info(
 					t(
 						"settingsIntegrationsZone.loadingMessageRetrievingGarminConnectActivities",
 					),
@@ -295,15 +298,16 @@ export default {
 				push.error(
 					`${t("settingsIntegrationsZone.errorMessageUnableToGetGarminConnectGear")} - ${error}`,
 				);
-			}
-		}
+}
+}
 
-		async function submitRetrieveGarminConnectHealthData(daysToRetrieveGarmin) {
-			try {
-				await garminConnect.getGarminConnectHealthDataLastDays(daysToRetrieveGarmin);
+async function submitRetrieveGarminConnectHealthData(dateRange) { // Parameter changed from daysToRetrieveGarmin to dateRange
+try {
+// Call the updated service method with startDate and endDate
+await garminConnect.getGarminConnectHealthDataByDates(dateRange.startDate, dateRange.endDate);
 
-				// Show the loading alert.
-				push.info(
+// Show the loading alert.
+push.info(
 					t("settingsIntegrationsZone.loadingMessageRetrievingGarminConnectHealthData"),
 				);
 			} catch (error) {

--- a/frontend/app/src/i18n/ca/components/settings/settingsIntegrationsZoneComponent.json
+++ b/frontend/app/src/i18n/ca/components/settings/settingsIntegrationsZoneComponent.json
@@ -4,6 +4,7 @@
     "buttonConnect": "Connecta",
     "buttonDropdownOptions": "Opcions",
     "modalRetrieveActivitiesByDaysTitle": "Recupera activitats per dies",
+    "modalRetrieveActivitiesByDateRangeTitle": "Recuperar activitats per interval de dates",
     "modalRetrieveActivitiesByDaysLabel": "Dies",
     "modalRetrieveActivitiesByDaysPlaceholder": "Dies",
     "modalRetrieveButton": "Recupera",
@@ -43,6 +44,7 @@
     "errorMessageUnableToGetGarminConnectGear": "No es pot obtenir equipament de Garmin Connect",
     "loadingMessageRetrievingGarminConnectGear": "Obtenint equipament de Garmin Connect",
     "modalRetrieveHealthDataByDaysTitle": "Recupera dades de salut per dies",
+    "modalRetrieveHealthDataByDateRangeTitle": "Recuperar dades de salut per interval de dates",
     "errorMessageUnableToGetGarminConnectHealthData": "No es poden obtenir dades de salut de Garmin Connect",
     "loadingMessageRetrievingGarminConnectHealthData": "Recuperant dades de salut de Garmin Connect"
 }

--- a/frontend/app/src/i18n/ca/generalItems.json
+++ b/frontend/app/src/i18n/ca/generalItems.json
@@ -42,5 +42,7 @@
     "labelPaceInMinKm": "Ritme en min/km",
     "labelPaceInMin100m": "Ritme en min/100m",
     "labelPaceInMinMile": "Ritme en min/mil",
-    "labelPaceInMin100yd": "Ritme en min/100yds"
+    "labelPaceInMin100yd": "Ritme en min/100yds",
+    "startDateLabel": "Data d'inici",
+    "endDateLabel": "Data de finalització"
 }

--- a/frontend/app/src/i18n/de/components/settings/settingsIntegrationsZoneComponent.json
+++ b/frontend/app/src/i18n/de/components/settings/settingsIntegrationsZoneComponent.json
@@ -4,6 +4,7 @@
     "buttonConnect": "Verbinden",
     "buttonDropdownOptions": "Optionen",
     "modalRetrieveActivitiesByDaysTitle": "Abrufen von Aktivitäten nach Tagen",
+    "modalRetrieveActivitiesByDateRangeTitle": "Aktivitäten nach Datumsbereich abrufen",
     "modalRetrieveActivitiesByDaysLabel": "Tage",
     "modalRetrieveActivitiesByDaysPlaceholder": "Tage",
     "modalRetrieveButton": "Abrufen",
@@ -43,6 +44,7 @@
     "errorMessageUnableToGetGarminConnectGear": "Garmin Connect Ausrüstung konnte nicht geladen werden",
     "loadingMessageRetrievingGarminConnectGear": "Garmin Connect Ausrüstung abrufen",
     "modalRetrieveHealthDataByDaysTitle": "Retrieve health data by days",
+    "modalRetrieveHealthDataByDateRangeTitle": "Gesundheitsdaten nach Datumsbereich abrufen",
     "errorMessageUnableToGetGarminConnectHealthData": "Unable to get Garmin Connect health data",
     "loadingMessageRetrievingGarminConnectHealthData": "Retrieving Garmin Connect health data"
 }

--- a/frontend/app/src/i18n/de/generalItems.json
+++ b/frontend/app/src/i18n/de/generalItems.json
@@ -42,5 +42,7 @@
     "labelPaceInMinKm": "Tempo in min/km",
     "labelPaceInMin100m": "Tempo in min/100m",
     "labelPaceInMinMile": "Tempo in min/Meile",
-    "labelPaceInMin100yd": "Pace in min/100yd"
+    "labelPaceInMin100yd": "Pace in min/100yd",
+    "startDateLabel": "Startdatum",
+    "endDateLabel": "Enddatum"
 }

--- a/frontend/app/src/i18n/es/components/settings/settingsIntegrationsZoneComponent.json
+++ b/frontend/app/src/i18n/es/components/settings/settingsIntegrationsZoneComponent.json
@@ -4,6 +4,7 @@
     "buttonConnect": "Conectar",
     "buttonDropdownOptions": "Opciones",
     "modalRetrieveActivitiesByDaysTitle": "Obtener actividades por días",
+    "modalRetrieveActivitiesByDateRangeTitle": "Recuperar actividades por rango de fechas",
     "modalRetrieveActivitiesByDaysLabel": "Días",
     "modalRetrieveActivitiesByDaysPlaceholder": "Días",
     "modalRetrieveButton": "Obtener",
@@ -43,6 +44,7 @@
     "errorMessageUnableToGetGarminConnectGear": "No se pudo obtener el equipo de Garmin Connect",
     "loadingMessageRetrievingGarminConnectGear": "Recuperando equipo de Garmin Connect",
     "modalRetrieveHealthDataByDaysTitle": "Obtener datos de salud por días",
+    "modalRetrieveHealthDataByDateRangeTitle": "Recuperar datos de salud por rango de fechas",
     "errorMessageUnableToGetGarminConnectHealthData": "No se han podido obtener datos de salud de Garmin Connect",
     "loadingMessageRetrievingGarminConnectHealthData": "Obteniendo datos de salud de Garmin Connect"
 }

--- a/frontend/app/src/i18n/es/generalItems.json
+++ b/frontend/app/src/i18n/es/generalItems.json
@@ -42,5 +42,7 @@
     "labelPaceInMinKm": "Ritmo en min/km",
     "labelPaceInMin100m": "Ritmo en min/100m",
     "labelPaceInMinMile": "Ritmo en min/milla",
-    "labelPaceInMin100yd": "Ritmo en min/100yd"
+    "labelPaceInMin100yd": "Ritmo en min/100yd",
+    "startDateLabel": "Fecha de inicio",
+    "endDateLabel": "Fecha final"
 }

--- a/frontend/app/src/i18n/fr/components/settings/settingsIntegrationsZoneComponent.json
+++ b/frontend/app/src/i18n/fr/components/settings/settingsIntegrationsZoneComponent.json
@@ -4,6 +4,7 @@
     "buttonConnect": "Connecter",
     "buttonDropdownOptions": "Options",
     "modalRetrieveActivitiesByDaysTitle": "Récupérer les activités par jours",
+    "modalRetrieveActivitiesByDateRangeTitle": "Récupérer les activités par période",
     "modalRetrieveActivitiesByDaysLabel": "Jours",
     "modalRetrieveActivitiesByDaysPlaceholder": "Jours",
     "modalRetrieveButton": "Récupérer",
@@ -43,6 +44,7 @@
     "errorMessageUnableToGetGarminConnectGear": "Impossible d'obtenir les équipements de Garmin Connect",
     "loadingMessageRetrievingGarminConnectGear": "Récupération des équipements de Garmin Connect",
     "modalRetrieveHealthDataByDaysTitle": "Récupérer les données de santé par jour",
+    "modalRetrieveHealthDataByDateRangeTitle": "Récupérer les données de santé par période",
     "errorMessageUnableToGetGarminConnectHealthData": "Impossible d'obtenir les données de santé de Garmin Connect",
     "loadingMessageRetrievingGarminConnectHealthData": "Récupération des données de santé de Garmin Connect"
 }

--- a/frontend/app/src/i18n/fr/generalItems.json
+++ b/frontend/app/src/i18n/fr/generalItems.json
@@ -42,5 +42,7 @@
     "labelPaceInMinKm": "Rythme en min/km",
     "labelPaceInMin100m": "Rythme en min/100m",
     "labelPaceInMinMile": "Rythme en min/mile",
-    "labelPaceInMin100yd": "Rythme en min/100yards"
+    "labelPaceInMin100yd": "Rythme en min/100yards",
+    "startDateLabel": "Date de début",
+    "endDateLabel": "Date de fin"
 }

--- a/frontend/app/src/i18n/nl/components/settings/settingsIntegrationsZoneComponent.json
+++ b/frontend/app/src/i18n/nl/components/settings/settingsIntegrationsZoneComponent.json
@@ -4,6 +4,7 @@
     "buttonConnect": "Verbinden",
     "buttonDropdownOptions": "Opties",
     "modalRetrieveActivitiesByDaysTitle": "Activiteiten ophalen per dag",
+    "modalRetrieveActivitiesByDateRangeTitle": "Activiteiten ophalen per datumbereik",
     "modalRetrieveActivitiesByDaysLabel": "Dagen",
     "modalRetrieveActivitiesByDaysPlaceholder": "Dagen",
     "modalRetrieveButton": "Ophalen",
@@ -43,6 +44,7 @@
     "errorMessageUnableToGetGarminConnectGear": "Kan geen Garmin Connect uitrusting krijgen",
     "loadingMessageRetrievingGarminConnectGear": "Ophalen van Garmin Connect uitrusting",
     "modalRetrieveHealthDataByDaysTitle": "Gezondheidsgegevens ophalen per dag",
+    "modalRetrieveHealthDataByDateRangeTitle": "Gezondheidsgegevens ophalen per datumbereik",
     "errorMessageUnableToGetGarminConnectHealthData": "Kan Garmin Connect gezondheidsgegevens niet ophalen",
     "loadingMessageRetrievingGarminConnectHealthData": "Ophalen van Garmin Connect gezondheidsgegevens"
 }

--- a/frontend/app/src/i18n/nl/generalItems.json
+++ b/frontend/app/src/i18n/nl/generalItems.json
@@ -42,5 +42,7 @@
     "labelPaceInMinKm": "Ritme in min/km",
     "labelPaceInMin100m": "Ritme in min/100m",
     "labelPaceInMinMile": "Ritme in min/mijl",
-    "labelPaceInMin100yd": "Ritme in min/100yd"
+    "labelPaceInMin100yd": "Ritme in min/100yd",
+    "startDateLabel": "Startdatum",
+    "endDateLabel": "Einddatum"
 }

--- a/frontend/app/src/i18n/pt/components/settings/settingsIntegrationsZoneComponent.json
+++ b/frontend/app/src/i18n/pt/components/settings/settingsIntegrationsZoneComponent.json
@@ -4,6 +4,7 @@
     "buttonConnect": "Associar",
     "buttonDropdownOptions": "Opções",
     "modalRetrieveActivitiesByDaysTitle": "Obter atividades por dias",
+    "modalRetrieveActivitiesByDateRangeTitle": "Recuperar atividades por intervalo de datas",
     "modalRetrieveActivitiesByDaysLabel": "Dias",
     "modalRetrieveActivitiesByDaysPlaceholder": "Dias",
     "modalRetrieveButton": "Obter",
@@ -43,6 +44,7 @@
     "errorMessageUnableToGetGarminConnectGear": "Não foi possível obter equipamento do Garmin Connect",
     "loadingMessageRetrievingGarminConnectGear": "A obter equipamento do Garmin Connect",
     "modalRetrieveHealthDataByDaysTitle": "Recuperar dados de saúde por dias",
+    "modalRetrieveHealthDataByDateRangeTitle": "Recuperar dados de saúde por intervalo de datas",
     "errorMessageUnableToGetGarminConnectHealthData": "Não foi possível obter dados de saúde do Garmin Connect",
     "loadingMessageRetrievingGarminConnectHealthData": "A obter dados de saúde do Garmin Connect"
 }

--- a/frontend/app/src/i18n/pt/generalItems.json
+++ b/frontend/app/src/i18n/pt/generalItems.json
@@ -42,5 +42,7 @@
     "labelPaceInMinKm": "Ritmo em min/km",
     "labelPaceInMin100m": "Ritmo em min/100m",
     "labelPaceInMinMile": "Ritmo em min/milha",
-    "labelPaceInMin100yd": "Ritmo em min/100jardas"
+    "labelPaceInMin100yd": "Ritmo em min/100jardas",
+    "startDateLabel": "Data de início",
+    "endDateLabel": "Data de fim"
 }

--- a/frontend/app/src/i18n/us/components/settings/settingsIntegrationsZoneComponent.json
+++ b/frontend/app/src/i18n/us/components/settings/settingsIntegrationsZoneComponent.json
@@ -3,8 +3,8 @@
     "stravaIntegrationBody": "Strava is an American internet service for tracking physical exercise which incorporates social network features.",
     "buttonConnect": "Connect",
     "buttonDropdownOptions": "Options",
-    "modalRetrieveActivitiesByDaysTitle": "Retrieve activities by days",
-    "modalRetrieveActivitiesByDaysLabel": "Days",
+    "modalRetrieveActivitiesByDateRangeTitle": "Retrieve Activities by Date Range",
+    "modalRetrieveActivitiesByDaysLabel": "Days", 
     "modalRetrieveActivitiesByDaysPlaceholder": "Days",
     "modalRetrieveButton": "Retrieve",
     "buttonRetrieveGear": "Retrieve gear",
@@ -42,7 +42,7 @@
     "errorMessageUnableToUnlinkGarminConnect": "Unable to unlink Garmin Connect account",
     "errorMessageUnableToGetGarminConnectGear": "Unable to get Garmin Connect gear",
     "loadingMessageRetrievingGarminConnectGear": "Retrieving Garmin Connect gear",
-    "modalRetrieveHealthDataByDaysTitle": "Retrieve health data by days",
+    "modalRetrieveHealthDataByDateRangeTitle": "Retrieve Health Data by Date Range",
     "errorMessageUnableToGetGarminConnectHealthData": "Unable to get Garmin Connect health data",
     "loadingMessageRetrievingGarminConnectHealthData": "Retrieving Garmin Connect health data"
 }

--- a/frontend/app/src/i18n/us/generalItems.json
+++ b/frontend/app/src/i18n/us/generalItems.json
@@ -42,5 +42,7 @@
     "labelPaceInMinKm": "Pace in min/km",
     "labelPaceInMin100m": "Pace in min/100m",
     "labelPaceInMinMile": "Pace in min/mile",
-    "labelPaceInMin100yd": "Pace in min/100yd"
+    "labelPaceInMin100yd": "Pace in min/100yd",
+    "startDateLabel": "Start Date",
+    "endDateLabel": "End Date"
 }

--- a/frontend/app/src/services/garminConnectService.js
+++ b/frontend/app/src/services/garminConnectService.js
@@ -9,18 +9,18 @@ export const garminConnect = {
 		return fetchPostRequest("garminconnect/link", data);
 	},
 	mfaGarminConnect(data) {
-		return fetchPostRequest("garminconnect/mfa", data);
-	},
-	getGarminConnectActivitiesLastDays(days) {
-		return fetchGetRequest(`garminconnect/activities/days/${days}`);
-	},
-	getGarminConnectGear() {
-		return fetchGetRequest("garminconnect/gear");
-	},
-	getGarminConnectHealthDataLastDays(days) {
-		return fetchGetRequest(`garminconnect/health/days/${days}`);
-	},
-	unlinkGarminConnect() {
+return fetchPostRequest("garminconnect/mfa", data);
+},
+getGarminConnectActivitiesByDates(startDate, endDate) { // Renamed and params changed
+return fetchGetRequest(`garminconnect/activities?start_date=${startDate}&end_date=${endDate}`); // Path and params updated
+},
+getGarminConnectGear() {
+return fetchGetRequest("garminconnect/gear");
+},
+getGarminConnectHealthDataByDates(startDate, endDate) { // Renamed and params changed
+return fetchGetRequest(`garminconnect/health?start_date=${startDate}&end_date=${endDate}`); // Path and params updated
+},
+unlinkGarminConnect() {
 		return fetchDeleteRequest("garminconnect/unlink");
 	},
 };


### PR DESCRIPTION
This pull request introduces significant changes to the Garmin integration, transitioning from "days-based" to "date-range-based" functionality for activity and health data retrieval. It includes backend updates to support date ranges, frontend modifications for user input, and improved error handling and logging.

### Backend Changes

#### Refactored Functions to Support Date Ranges:
* `fetch_and_process_activities_by_dates` and `fetch_and_process_bc_by_dates`: Updated to accept `start_date` and `end_date` parameters instead of calculating based on days. These functions now fetch data within a specific date range, improving flexibility. [[1]](diffhunk://#diff-b0eb2bf5c623003d1281aa4942782386b33f1316ad69ad6a644370116f04bcc1L20-R164) [[2]](diffhunk://#diff-89456469eae21e5b44434f29d98801443c263aa4e4a301bc6027284a9523b01eL19-R42)
* `get_user_garminconnect_activities_by_dates` and `get_user_garminconnect_bc_by_dates`: Replaced the previous "days-based" functions to handle date ranges. Added detailed logging for the date range being processed. [[1]](diffhunk://#diff-b0eb2bf5c623003d1281aa4942782386b33f1316ad69ad6a644370116f04bcc1L20-R164) [[2]](diffhunk://#diff-89456469eae21e5b44434f29d98801443c263aa4e4a301bc6027284a9523b01eL109-L130)

#### Enhanced Error Handling and Logging:
* Improved exception handling in multiple functions to log errors more descriptively, including the date range being processed. [[1]](diffhunk://#diff-b0eb2bf5c623003d1281aa4942782386b33f1316ad69ad6a644370116f04bcc1L20-R164) [[2]](diffhunk://#diff-89456469eae21e5b44434f29d98801443c263aa4e4a301bc6027284a9523b01eL19-R42)

### Frontend Changes

#### New Date Range Modal Component:
* Added `ModalComponentDateRangeInput.vue`: A reusable modal for selecting start and end dates, with default values pre-set to the last 7 days. This component emits the selected date range for further processing.

#### Updated UI for Garmin Data Retrieval:
* Modified dropdown menu in `SettingsIntegrationsZone.vue` to replace "days-based" options with "date-range-based" options for both activity and health data retrieval.

### API Changes

* Updated `/activities` and `/health` endpoints to accept `start_date` and `end_date` parameters instead of `days`. Adjusted background tasks to use the new date range methods. [[1]](diffhunk://#diff-5a7451446b563bac9a937c9d7a41472188585ccdf556cd740402533a1565316aL76-R96) [[2]](diffhunk://#diff-5a7451446b563bac9a937c9d7a41472188585ccdf556cd740402533a1565316aL131-R154)