### PR TITLE
don't encrypt Garmin mfa_token when None

### DIFF
--- a/backend/app/core/cryptography.py
+++ b/backend/app/core/cryptography.py
@@ -29,9 +29,7 @@ def encrypt_token_fernet(token) -> str:
         cipher = create_fernet_cipher()
 
         # Convert to string if token is not already a string
-        if not token:
-            token = ""
-        elif not isinstance(token, str):
+        if not isinstance(token, str):
             token = str(token)
             
         # Encrypt the token

--- a/backend/app/core/cryptography.py
+++ b/backend/app/core/cryptography.py
@@ -29,7 +29,9 @@ def encrypt_token_fernet(token) -> str:
         cipher = create_fernet_cipher()
 
         # Convert to string if token is not already a string
-        if not isinstance(token, str):
+        if not token:
+            token = ""
+        elif not isinstance(token, str):
             token = str(token)
             
         # Encrypt the token

--- a/backend/app/garmin/utils.py
+++ b/backend/app/garmin/utils.py
@@ -166,7 +166,11 @@ def serialize_oauth1_token(token):
             "oauth_token_secret": core_cryptography.encrypt_token_fernet(
                 token.oauth_token_secret
             ),
-            "mfa_token": core_cryptography.encrypt_token_fernet(token.mfa_token),
+            "mfa_token": (
+                core_cryptography.encrypt_token_fernet(token.mfa_token)
+                if token.mfa_token
+                else None
+            ),
             "mfa_expiration_timestamp": (
                 token.mfa_expiration_timestamp.isoformat()
                 if token.mfa_expiration_timestamp
@@ -212,7 +216,11 @@ def deserialize_oauth1_token(data):
             oauth_token_secret=core_cryptography.decrypt_token_fernet(
                 data["oauth_token_secret"]
             ),
-            mfa_token=core_cryptography.decrypt_token_fernet(data.get("mfa_token")),
+            mfa_token=(
+                core_cryptography.decrypt_token_fernet(data.get("mfa_token"))
+                if data.get("mfa_token")
+                else None
+            ),
             mfa_expiration_timestamp=(
                 datetime.fromisoformat(data["mfa_expiration_timestamp"])
                 if data.get("mfa_expiration_timestamp")


### PR DESCRIPTION
The encryption logic in [`core.cryptography.encrypt_token_fernet`](https://github.com/joaovitoriasilva/endurain/blob/master/backend/app/core/cryptography.py#L32-L33) converts `None` to `"None"` before encryption.

This PR ensures we're checking if `oauth1_token.mfa_token` is `None` before attempting to encrypt.

Closes #178