### PR TITLE
Add support for gzipped activity files

### DIFF
--- a/backend/app/activities/activity/utils.py
+++ b/backend/app/activities/activity/utils.py
@@ -477,14 +477,11 @@ def parse_and_store_activity_from_uploaded_file(
                     f"File extension not supported: {file_extension}", "error"
                 )
 
-            # Define the directory where the processed files will be stored
-            processed_dir = "files/processed"
-
             # Define new file path with activity ID as filename
             new_file_name = f"{idsToFileName}{file_extension}"
 
             # Move the file to the processed directory
-            move_file(processed_dir, new_file_name, file_path)
+            move_file(PROCESSED_DIR, new_file_name, file_path)
 
             for activity in created_activities:
                 # Serialize the activity

--- a/backend/app/activities/activity/utils.py
+++ b/backend/app/activities/activity/utils.py
@@ -297,6 +297,9 @@ def parse_and_store_activity_from_file(
         if from_garmin:
             garmin_connect_activity_id = os.path.basename(file_path).split("_")[0]
 
+        if file_extension.lower() == ".gz":
+            file_path, file_extension = handle_gzipped_file(file_path)
+
         user = users_crud.get_user_by_id(token_user_id, db)
         if user is None:
             raise HTTPException(
@@ -309,9 +312,6 @@ def parse_and_store_activity_from_file(
                 user.id, db
             )
         )
-
-        if file_extension.lower() == ".gz":
-            file_path, file_extension = handle_gzipped_file(file_path)
 
         # Parse the file
         parsed_info = parse_file(
@@ -411,6 +411,9 @@ def parse_and_store_activity_from_uploaded_file(
         with open(file_path, "wb") as save_file:
             save_file.write(file.file.read())
 
+        if file_extension.lower() == ".gz":
+            file_path, file_extension = handle_gzipped_file(file_path)
+
         user = users_crud.get_user_by_id(token_user_id, db)
         if user is None:
             raise HTTPException(
@@ -423,9 +426,6 @@ def parse_and_store_activity_from_uploaded_file(
                 user.id, db
             )
         )
-
-        if file_extension.lower() == ".gz":
-            file_path, file_extension = handle_gzipped_file(file_path)
 
         # Parse the file
         parsed_info = parse_file(

--- a/frontend/app/src/views/HomeView.vue
+++ b/frontend/app/src/views/HomeView.vue
@@ -54,7 +54,7 @@
 							<div class="modal-body">
 								<!-- date fields -->
 								<label for="activityGpxFileAdd"><b>* {{ $t("homeView.fieldLabelUploadGPXFile") }}</b></label>
-								<input class="form-control mt-1 mb-1" type="file" name="activityGpxFileAdd" accept=".gpx,.fit" required>
+								<input class="form-control mt-1 mb-1" type="file" name="activityGpxFileAdd" accept=".gz,.gpx,.fit" required>
 								<p>* {{ $t("generalItems.requiredField") }}</p>
 							</div>
 							<div class="modal-footer">


### PR DESCRIPTION
Related to #207

I had started to get deep in the weeds on refactoring as a part of this change but I'm going to break that off into other PRs and start with just a small one!

This PR covers:
 - pull `PROCESSED_DIR` into a constant
 - add a `handle_gzipped_file` that is used by the file parsing methods. It moves the archive filed into the processed dir, then passes the inner file to the rest of the flow.
 - `parse_and_store_activity_from_file` had an `open` that was never used so I removed that to clean it up. The diff makes it look like that section is all edited but its really just been unintended.
 - Added `.gz` to `accept` in the frontend file upload. I see that there is also text in each langauge mentioning ".gpx" and ".fit", do you want that updated? If so what message makes sense?

I think I'll try to add a test in a different PR to keep this one smaller. I've tested locally by uploading several files from my archive. 

Let me know if you'd like any other changes.