### PR TITLE
Read ENDURAIN_HOST from config.json

### DIFF
--- a/frontend/app/public/config.json
+++ b/frontend/app/public/config.json
@@ -1,0 +1,3 @@
+{
+  "ENDURAIN_HOST": "http://localhost:8080"
+}

--- a/frontend/app/src/components/Users/UserAvatarComponent.vue
+++ b/frontend/app/src/components/Users/UserAvatarComponent.vue
@@ -7,7 +7,9 @@
   
 <script>
 import { ref } from 'vue';
-  
+import {getConfig} from "@/utils/configUtils.js";
+const config = await getConfig();
+
 export default {
     props: {
         user: {
@@ -31,7 +33,7 @@ export default {
     emits: ['userDeleted'],
     setup(props) {
         const altText = ref('User Avatar');
-        const userPhotoUrl = ref(props.user?.photo_path ? `${import.meta.env.VITE_ENDURAIN_HOST}/${props.user.photo_path}` : null);
+        const userPhotoUrl = ref(props.user?.photo_path ? `${config?.ENDURAIN_HOST}/${props.user.photo_path}` : null);
         const alignTopValue = ref(props.alignTop);
 
         return {

--- a/frontend/app/src/services/stravaService.js
+++ b/frontend/app/src/services/stravaService.js
@@ -1,4 +1,6 @@
 import { fetchGetRequest, fetchPutRequest, fetchDeleteRequest } from '@/utils/serviceUtils';
+import {getConfig} from "@/utils/configUtils.js";
+const config = await getConfig();
 
 export const strava = {
     setUniqueUserStateStravaLink(state) {
@@ -12,7 +14,7 @@ export const strava = {
         return fetchPutRequest('strava/client', data);
     },
     linkStrava(state, stravaClientId) {
-        let redirectUri = `${import.meta.env.VITE_ENDURAIN_HOST}`;
+        let redirectUri = `${config?.ENDURAIN_HOST}`;
         redirectUri = encodeURIComponent(redirectUri);
         const scope = 'read,read_all,profile:read_all,activity:read,activity:read_all';
 

--- a/frontend/app/src/utils/configUtils.js
+++ b/frontend/app/src/utils/configUtils.js
@@ -1,0 +1,14 @@
+let externalConfig = null;
+
+export async function getConfig() {
+    if (externalConfig !== null) {
+        return externalConfig;
+    }
+    return await fetch('/config.json')
+      .then(response => response.json())
+      .then(config => {
+          externalConfig = config;
+      });
+}
+
+await getConfig();

--- a/frontend/app/src/utils/serviceUtils.js
+++ b/frontend/app/src/utils/serviceUtils.js
@@ -1,10 +1,12 @@
 // Importing the auth store
 import { useAuthStore } from "@/stores/authStore";
+import { getConfig } from "@/utils/configUtils.js";
 
 let refreshTokenPromise = null;
 
-export const API_URL = `${import.meta.env.VITE_ENDURAIN_HOST}/api/v1/`;
-export const FRONTEND_URL = `${import.meta.env.VITE_ENDURAIN_HOST}/`;
+const config = await getConfig();
+export const API_URL = `${config?.ENDURAIN_HOST}/api/v1/`;
+export const FRONTEND_URL = `${config?.ENDURAIN_HOST}/`;
 
 async function fetchWithRetry(url, options) {
 	// Add CSRF token to headers for state-changing requests

--- a/frontend/app/src/views/LoginView.vue
+++ b/frontend/app/src/views/LoginView.vue
@@ -50,6 +50,8 @@ import { useServerSettingsStore } from "@/stores/serverSettingsStore";
 // Importing the services for the login
 import { session } from "@/services/sessionService";
 import { profile } from "@/services/profileService";
+import {getConfig} from "@/utils/configUtils.js";
+const config = await getConfig();
 
 // Exporting the default object
 export default {
@@ -65,7 +67,7 @@ export default {
 		const serverSettingsStore = useServerSettingsStore();
 		const showPassword = ref(false);
 		const loginPhotoUrl = serverSettingsStore.serverSettings.login_photo_set
-			? `${import.meta.env.VITE_ENDURAIN_HOST}/server_images/login.png`
+			? `${config?.ENDURAIN_HOST}/server_images/login.png`
 			: null;
 
 		// Toggle password visibility

--- a/frontend/app/vite.config.js
+++ b/frontend/app/vite.config.js
@@ -86,5 +86,10 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
+  },
+  esbuild: {
+    supported: {
+      'top-level-await': true
+    }
   }
 })


### PR DESCRIPTION
Addresses #213 
 
This adds a config.json in the frontend/app/public dir which can store non-sensitive runtime configuration without the need for sed. I've used this approach several times in other applications, though not in Vue so the implementation may not be idiomatic.