### PR TITLE
Fix error that occurs while handling the error ('module' object is not callable)

### DIFF
--- a/backend/app/activities/activity_streams/crud.py
+++ b/backend/app/activities/activity_streams/crud.py
@@ -496,7 +496,7 @@ def create_activity_streams(
         db.rollback()
 
         # Log the exception
-        core_logger(f"Error in create_activity_streams: {err}", "error", exc=err)
+        core_logger.print_to_log_and_console(f"Error in create_activity_streams: {err}", "error", exc=err)
         # Raise an HTTPException with a 500 Internal Server Error status code
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
I was working in the endurain codebase, and triggered an error. While handling this error, the `core_logger` module was used as a callable (which it isn't). This PR fixes that by using one of the methods of the `core_logger` module.