### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ ENDURAIN_HOST=https://endurain.example.com
 BEHIND_PROXY=true
 POSTGRES_DB=endurain
 POSTGRES_USER=endurain
+PGDATA=/var/lib/postgresql/data/pgdata


### PR DESCRIPTION
Docker compose ends up in errors without the PGDATA env. Docs also state it is required, but missing in the default .env file.
