### PR TITLE
Revise bulk import procedure to better handle error-producing files

### DIFF
--- a/backend/app/activities/activity/router.py
+++ b/backend/app/activities/activity/router.py
@@ -585,7 +585,7 @@ async def create_activity_with_bulk_import(
                     file_path,
                     db,
                 )
-
+        core_logger.print_to_log_and_console("Bulk import initiated for all files found in bulk_import directory. Processing files will continue in the background.")
         # Return a success message
         return {"Bulk import initiated for all files found in bulk_import directory. Processing files will continue in the background."}
     except Exception as err:

--- a/backend/app/activities/activity/router.py
+++ b/backend/app/activities/activity/router.py
@@ -575,7 +575,7 @@ async def create_activity_with_bulk_import(
 
             if os.path.isfile(file_path):
                 # Log the file being processed
-                core_logger.print_to_log_and_console(f"Processing file: {file_path}")
+                core_logger.print_to_log_and_console(f"Queuing file for processing: {file_path}")
                 # Parse and store the activity
                 background_tasks.add_task(
                     activities_utils.parse_and_store_activity_from_file,

--- a/backend/app/activities/activity/router.py
+++ b/backend/app/activities/activity/router.py
@@ -565,6 +565,8 @@ async def create_activity_with_bulk_import(
     background_tasks: BackgroundTasks,
 ):
     try:
+        core_logger.print_to_log_and_console("Bulk import initiated.")
+
         # Ensure the 'bulk_import' directory exists
         bulk_import_dir = core_config.FILES_BULK_IMPORT_DIR
         os.makedirs(bulk_import_dir, exist_ok=True)
@@ -585,7 +587,7 @@ async def create_activity_with_bulk_import(
                 )
 
         # Return a success message
-        return {"Bulk import initiated. Processing files in the background."}
+        return {"Bulk import initiated for all files found in bulk_import directory. Processing files will continue in the background."}
     except Exception as err:
         # Log the exception
         core_logger.print_to_log(

--- a/backend/app/activities/activity/utils.py
+++ b/backend/app/activities/activity/utils.py
@@ -289,7 +289,6 @@ def parse_and_store_activity_from_file(
                     user.id, db
                 )
             )
-            core_logger.print_to_log_and_console(f"Bulk file import: File opened - {file_path}") # Testing code
 
             # Parse the file
             parsed_info = parse_file(
@@ -299,8 +298,6 @@ def parse_and_store_activity_from_file(
                 file_path,
                 db,
             )
-            core_logger.print_to_log_and_console(f"Bulk file import: File parsed - {file_path}") # Testing code
-
 
             if parsed_info is not None:
                 created_activities = []
@@ -310,13 +307,11 @@ def parse_and_store_activity_from_file(
                     created_activity = store_activity(parsed_info, db)
                     created_activities.append(created_activity)
                     idsToFileName = idsToFileName + str(created_activity.id)
-                    core_logger.print_to_log_and_console(f"Bulk file import: GPX file parsed and stored - {file_path}") # Testing code
                 elif file_extension.lower() == ".fit":
                     # Split the records by activity (check for multiple activities in the file)
                     split_records_by_activity = fit_utils.split_records_by_activity(
                         parsed_info
                     )
-                    core_logger.print_to_log_and_console(f"Bulk file import: .fit file split - {file_path}") # Testing code
                     # Create activity objects for each activity in the file
                     if from_garmin:
                         created_activities_objects = fit_utils.create_activity_objects(
@@ -327,7 +322,6 @@ def parse_and_store_activity_from_file(
                             garminconnect_gear,
                             db,
                         )
-                        core_logger.print_to_log_and_console(f"Bulk file import: .fit from garmin processed - {file_path}") # Testing code
                     else:
                         created_activities_objects = fit_utils.create_activity_objects(
                             split_records_by_activity,
@@ -337,14 +331,10 @@ def parse_and_store_activity_from_file(
                             None,
                             db,
                         )
-                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file of generic origin processed - {file_path}") # Testing code
                     for activity in created_activities_objects:
                         # Store the activity in the database
-                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file stored 0- {file_path}") # Testing code
                         created_activity = store_activity(activity, db)
-                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file stored 1- {file_path}") # Testing code
                         created_activities.append(created_activity)
-                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file stored 2- {file_path}") # Testing code
                     for index, activity in enumerate(created_activities):
                         idsToFileName += str(activity.id)  # Add the id to the string
                         # Add an underscore if it's not the last item
@@ -365,7 +355,7 @@ def parse_and_store_activity_from_file(
                 move_file(processed_dir, new_file_name, file_path)
 
                 # Return the created activity
-                core_logger.print_to_log_and_console(f"Bulk file import: File successfully processed and moved - {file_path} - has become {new_file_name}")
+                core_logger.print_to_log_and_console(f"Bulk file import: File successfully processed and moved. {file_path} - has become {new_file_name}")
                 return created_activities
             else:
                 return None
@@ -380,9 +370,9 @@ def parse_and_store_activity_from_file(
             error_file_dir = os.path.join(bulk_import_dir, "import_errors")
             os.makedirs(error_file_dir, exist_ok=True)
             move_file(error_file_dir, os.path.basename(file_path), file_path)
-            core_logger.print_to_log_and_console(f"Bulk file import: File {file_path} moved to {error_file_dir}")
+            core_logger.print_to_log_and_console(f"Bulk file import: Due to import error, file {file_path} has been moved to {error_file_dir}")
         except:
-            core_logger.print_to_log_and_console(f"Bulk file import: Okay, we are having a bad day, boss.  Moving the error-producing file {file_path} failed.")
+            core_logger.print_to_log_and_console(f"Bulk file import: Okay, we are having a bad day, boss. Moving the error-producing file {file_path} to the import-error directory failed.")
 
 def parse_and_store_activity_from_uploaded_file(
     token_user_id: int, file: UploadFile, db: Session

--- a/backend/app/activities/activity/utils.py
+++ b/backend/app/activities/activity/utils.py
@@ -266,6 +266,8 @@ def parse_and_store_activity_from_file(
     garminconnect_gear: dict = None,
 ):
     try:
+        core_logger.print_to_log_and_console(f"Bulk file import: Beginning processing of {file_path}")
+
         # Get file extension
         _, file_extension = os.path.splitext(file_path)
         garmin_connect_activity_id = None
@@ -287,6 +289,7 @@ def parse_and_store_activity_from_file(
                     user.id, db
                 )
             )
+            core_logger.print_to_log_and_console(f"Bulk file import: File opened - {file_path}") # Testing code
 
             # Parse the file
             parsed_info = parse_file(
@@ -296,6 +299,8 @@ def parse_and_store_activity_from_file(
                 file_path,
                 db,
             )
+            core_logger.print_to_log_and_console(f"Bulk file import: File parsed - {file_path}") # Testing code
+
 
             if parsed_info is not None:
                 created_activities = []
@@ -305,12 +310,13 @@ def parse_and_store_activity_from_file(
                     created_activity = store_activity(parsed_info, db)
                     created_activities.append(created_activity)
                     idsToFileName = idsToFileName + str(created_activity.id)
+                    core_logger.print_to_log_and_console(f"Bulk file import: GPX file parsed and stored - {file_path}") # Testing code
                 elif file_extension.lower() == ".fit":
                     # Split the records by activity (check for multiple activities in the file)
                     split_records_by_activity = fit_utils.split_records_by_activity(
                         parsed_info
                     )
-
+                    core_logger.print_to_log_and_console(f"Bulk file import: .fit file split - {file_path}") # Testing code
                     # Create activity objects for each activity in the file
                     if from_garmin:
                         created_activities_objects = fit_utils.create_activity_objects(
@@ -321,6 +327,7 @@ def parse_and_store_activity_from_file(
                             garminconnect_gear,
                             db,
                         )
+                        core_logger.print_to_log_and_console(f"Bulk file import: .fit from garmin processed - {file_path}") # Testing code
                     else:
                         created_activities_objects = fit_utils.create_activity_objects(
                             split_records_by_activity,
@@ -330,12 +337,12 @@ def parse_and_store_activity_from_file(
                             None,
                             db,
                         )
-
+                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file of generic origin processed - {file_path}") # Testing code
                     for activity in created_activities_objects:
                         # Store the activity in the database
                         created_activity = store_activity(activity, db)
                         created_activities.append(created_activity)
-
+                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file stored - {file_path}") # Testing code
                     for index, activity in enumerate(created_activities):
                         idsToFileName += str(activity.id)  # Add the id to the string
                         # Add an underscore if it's not the last item
@@ -344,9 +351,8 @@ def parse_and_store_activity_from_file(
                                 "_"  # Add an underscore if it's not the last item
                             )
                 else:
-                    core_logger.print_to_log_and_console(
-                        f"File extension not supported: {file_extension}", "error"
-                    )
+                    # Should no longer get here due to screening of extensions in router.py
+                    core_logger.print_to_log_and_console(f"File extension not supported: {file_extension}", "error")
                 # Define the directory where the processed files will be stored
                 processed_dir = core_config.FILES_PROCESSED_DIR
 
@@ -357,6 +363,7 @@ def parse_and_store_activity_from_file(
                 move_file(processed_dir, new_file_name, file_path)
 
                 # Return the created activity
+                core_logger.print_to_log_and_console(f"Bulk file import: File successfully processed and moved - {file_path} - has become {new_file_name}")
                 return created_activities
             else:
                 return None

--- a/backend/app/activities/activity/utils.py
+++ b/backend/app/activities/activity/utils.py
@@ -340,9 +340,11 @@ def parse_and_store_activity_from_file(
                         core_logger.print_to_log_and_console(f"Bulk file import: .fit file of generic origin processed - {file_path}") # Testing code
                     for activity in created_activities_objects:
                         # Store the activity in the database
+                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file stored 0- {file_path}") # Testing code
                         created_activity = store_activity(activity, db)
+                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file stored 1- {file_path}") # Testing code
                         created_activities.append(created_activity)
-                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file stored - {file_path}") # Testing code
+                        core_logger.print_to_log_and_console(f"Bulk file import: .fit file stored 2- {file_path}") # Testing code
                     for index, activity in enumerate(created_activities):
                         idsToFileName += str(activity.id)  # Add the id to the string
                         # Add an underscore if it's not the last item

--- a/backend/app/activities/activity/utils.py
+++ b/backend/app/activities/activity/utils.py
@@ -366,6 +366,7 @@ def parse_and_store_activity_from_file(
         # Log the exception
         core_logger.print_to_log_and_console(f"Bulk file import: Error while parsing {file_path} in parse_and_store_activity_from_file - {str(err)}", "error")
         try:
+            # Move the exception-causing file to an import errors directory.
             bulk_import_dir = core_config.FILES_BULK_IMPORT_DIR
             error_file_dir = os.path.join(bulk_import_dir, "import_errors")
             os.makedirs(error_file_dir, exist_ok=True)


### PR DESCRIPTION
This pull is to resolve issue #250, incorporating three major changes:

1) Stopped the crash that was causing bulk-import to crash when encountering un-parseable files (by removing the raising of an http_err by the exception handling code, since background tasks apparently cannot raise this error).

2) Implemented code to move error-producing files into a bulk import errors folder ("files/bulk_import/import_errors").  This errors folder is dynamically created as a derivative of the bulk_import folder, so no core-config file changes are needed, and this code should be compatible with the renaming of folders in v0.13.

3) Clarified the log statements that are created as bulk imports occur.  The biggest change here is that the router.py file now states that it is "queuing files for processing" (since that is all it does), and when the files are actually processed in utils.py appropriate statements are added to the log.