### PR TITLE
Fix inconcistency for pgdata path between .env.example and docker-compose.yml.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,4 @@ ENDURAIN_HOST=https://endurain.example.com
 BEHIND_PROXY=true
 POSTGRES_DB=endurain
 POSTGRES_USER=endurain
-PGDATA=/var/lib/postgresql/data/pgdata
+PGDATA=/var/lib/postgresql/data


### PR DESCRIPTION
If set to `/var/lib/postgresql/data/pgdata` postgres doesn't start (_no such file or directory_)
For easier setup when following the docs it should be the same as docker-compose.yml.example (`/var/lib/postgresql/data`)