### PR TITLE
fix HR zones assignment

### DIFF
--- a/backend/app/activities/activity_streams/crud.py
+++ b/backend/app/activities/activity_streams/crud.py
@@ -393,10 +393,10 @@ def transform_activity_streams_hr(activity_stream, activity, db):
     max_heart_rate = 220 - (current_year - year)
 
     # Calculate heart rate zones based on the maximum heart rate
-    zone_1 = max_heart_rate * 0.5
-    zone_2 = max_heart_rate * 0.6
-    zone_3 = max_heart_rate * 0.7
-    zone_4 = max_heart_rate * 0.8
+    zone_1 = max_heart_rate * 0.6
+    zone_2 = max_heart_rate * 0.7
+    zone_3 = max_heart_rate * 0.8
+    zone_4 = max_heart_rate * 0.9
 
     # Extract heart rate values from waypoints
     hr_values = np.array(


### PR DESCRIPTION
HR measures were wrongly assigned to the previous zone.

**Before**
zone 1 was less than 50%
zone 2 went from 50% to 60%
and  so on. 

That's wrong because zone 1 goes from 50% to 60%, etc.
I changed this considering HR less than 50% as belonging to zone 1.

**New behaviour**
zone 1 is less than 60%
zone 2 goes from 60% to 70%
zone 3 goes from 70% to 80%
zone 4 goes from 80% to 90%
zone 5 is greater than 90%

This works fine in my environment.