### PR TITLE
Fixing issue 361 - errors in Strava bike import routine

### DIFF
--- a/backend/app/gears/gear/crud.py
+++ b/backend/app/gears/gear/crud.py
@@ -335,14 +335,14 @@ def create_multiple_gears(gears: list[gears_schema.Gear], user_id: int, db: Sess
             for gear in (gears or [])
             if gear is not None
             and getattr(gear, "nickname", None)
-            and str(gear.nickname).strip()
+            and str(gear.nickname).replace("+", " ").strip()
         ]
 
         # 2) De-dupe within the valid_gears payload (case-insensitive, trimmed)
         seen = set()
         deduped: list[gears_schema.Gear] = []
         for gear in valid_gears:
-            nickname_normalized = str(gear.nickname).replace("+", " ").strip()
+            nickname_normalized = str(gear.nickname).replace("+", " ").lower().strip()
             if nickname_normalized not in seen:
                 seen.add(nickname_normalized)
                 deduped.append(gear)

--- a/backend/app/strava/gear_utils.py
+++ b/backend/app/strava/gear_utils.py
@@ -287,7 +287,7 @@ def transform_csv_bike_gear_to_schema_gear(
             model=bikes_dict[bike]["Bike Model"],
             nickname=bike,
             gear_type=gears_utils.GEAR_NAME_TO_ID["bike"],
-            is_active=True,
+            active=True,
             strava_gear_id=None,
         )
         gears.append(new_gear)


### PR DESCRIPTION
This is a fix for #361 - two errors in the v0.15-rc3 regarding Strava bike import.

1 - Fixes mis-named variable in backend/app/strava/gear_utils.py

2 - Cleans up duplicate checking routine in backend/app/gears/gear/crud.py

With these edits our bikes.csv test file (attached to #361) imports properly:

<img width="905" height="590" alt="image" src="https://github.com/user-attachments/assets/f98d590c-5b40-4477-ba6b-ae0dc03e615f" />
