### PR TITLE
Add support for heart rate extraction from GPX files from Tissot Smar…

### DIFF
--- a/backend/app/gpx/utils.py
+++ b/backend/app/gpx/utils.py
@@ -161,8 +161,8 @@ def parse_gpx_file(
                                             # Extract 'power' value
                                             power = extension.text
                                         elif extension.tag.endswith("heartrate"):
-                                            # Tissot T-Touch smartwatch and similar devices extension
-                                            heart_rate = extension.text
+                                            # Tissot smartwatch and similar devices extension
+                                            heart_rate = int(extension.text) if extension.text else 0
 
                                 # Check if heart rate, cadence, power are set
                                 if heart_rate != 0:


### PR DESCRIPTION
XML looks like this (anonymized)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<gpx creator="Tissot T-Touch Connect Sport" data_type="gpx" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
    <metadata>
        <name>Running on Friday</name>
        <time>2025-10-10T14:28:09Z</time>
    </metadata>
    <trk>
        <type>Run</type>
        <trkseg>
            <trkpt lat="47.1234567" lon="8.1234567">
                <ele>500.0</ele>
                <time>2025-10-10T14:28:09Z</time>
                <extensions>
                    <heartrate>85</heartrate>
                </extensions>
            </trkpt>
            <trkpt lat="47.1234568" lon="8.1234568">
                <ele>500.1</ele>
                <time>2025-10-10T14:28:15Z</time>
                <extensions>
                    <heartrate>86</heartrate>
                </extensions>
            </trkpt>
            <trkpt lat="47.1234569" lon="8.1234569">
                <ele>500.2</ele>
                <time>2025-10-10T14:28:19Z</time>
                <extensions>
                    <heartrate>89</heartrate>
                </extensions>
            </trkpt>
            <trkpt lat="47.1234570" lon="8.1234570">
                <ele>500.3</ele>
                <time>2025-10-10T14:28:25Z</time>
                <extensions>
                    <heartrate>91</heartrate>
                </extensions>
            </trkpt>
            <trkpt lat="47.1234571" lon="8.1234571">
                <ele>500.4</ele>
                <time>2025-10-10T14:28:29Z</time>
                <extensions>
                    <heartrate>93</heartrate>
                </extensions>
            </trkpt>
        </trkseg>
    </trk>
</gpx>
```