### PR TITLE
feat: Add user max heart rate override for HR zone calculations

### DIFF
--- a/backend/app/activities/activity_streams/crud.py
+++ b/backend/app/activities/activity_streams/crud.py
@@ -383,14 +383,21 @@ def transform_activity_streams_hr(activity_stream, activity, db):
 
     # Get the user details to calculate heart rate zones
     detail_user = users_crud.get_user_by_id(activity.user_id, db)
-    if not detail_user or not detail_user.birthdate:
-        # If user details are not available or birthdate is missing, return the activity stream as is
+    if not detail_user:
+        # If user details are not available, return the activity stream as is
         return activity_stream
 
-    # Calculate the maximum heart rate based on the user's birthdate
-    year = int(detail_user.birthdate.split("-")[0])
-    current_year = datetime.datetime.now().year
-    max_heart_rate = 220 - (current_year - year)
+    # Use user's max_heart_rate if set, otherwise calculate based on age formula
+    if detail_user.max_heart_rate:
+        max_heart_rate = detail_user.max_heart_rate
+    elif detail_user.birthdate:
+        # Calculate the maximum heart rate based on the user's birthdate
+        year = int(detail_user.birthdate.split("-")[0])
+        current_year = datetime.datetime.now().year
+        max_heart_rate = 220 - (current_year - year)
+    else:
+        # If neither max_heart_rate nor birthdate is available, return the activity stream as is
+        return activity_stream
 
     # Calculate heart rate zones based on the maximum heart rate
     zone_1 = max_heart_rate * 0.6

--- a/backend/app/alembic/versions/v0_16_0_migration.py
+++ b/backend/app/alembic/versions/v0_16_0_migration.py
@@ -1,0 +1,36 @@
+"""v0.16.0 migration - Add max_heart_rate to users
+
+Revision ID: 9d8e7f6a5b4c
+Revises: 3c4d5e6f7a8b
+Create Date: 2025-11-03 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "9d8e7f6a5b4c"
+down_revision: Union[str, None] = "3c4d5e6f7a8b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add max_heart_rate column to users table
+    op.add_column(
+        "users",
+        sa.Column(
+            "max_heart_rate",
+            sa.Integer(),
+            nullable=True,
+            comment="User maximum heart rate (bpm)",
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Remove max_heart_rate column from users table
+    op.drop_column("users", "max_heart_rate")

--- a/backend/app/users/user/models.py
+++ b/backend/app/users/user/models.py
@@ -52,6 +52,9 @@ class User(Base):
         comment="User units (one digit)(1 - metric, 2 - imperial)",
     )
     height = Column(Integer, nullable=True, comment="User height in centimeters")
+    max_heart_rate = Column(
+        Integer, nullable=True, comment="User maximum heart rate (bpm)"
+    )
     access_type = Column(
         Integer, nullable=False, comment="User type (one digit)(1 - user, 2 - admin)"
     )

--- a/backend/app/users/user/schema.py
+++ b/backend/app/users/user/schema.py
@@ -119,6 +119,7 @@ class UserBase(BaseModel):
     gender: Gender = Gender.MALE
     units: server_settings_schema.Units = server_settings_schema.Units.METRIC
     height: int | None = None
+    max_heart_rate: int | None = None
     first_day_of_week: WeekDay = WeekDay.MONDAY
     currency: server_settings_schema.Currency = server_settings_schema.Currency.EURO
 

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -143,6 +143,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1780,6 +1781,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1826,6 +1828,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2475,6 +2478,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -2782,6 +2786,7 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3353,6 +3358,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -3991,6 +3997,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4327,6 +4334,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4478,6 +4486,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
       "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -5141,6 +5150,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5202,6 +5212,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5249,6 +5260,7 @@
       "integrity": "sha512-7BZHsG3kC2vei8F2W8hnfDi9RK+cv5eKPMvzBdrl8Vuc0hR5odGQRli8VVzUkrmUHkxFEm4Iio1r5HOKslO0Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -7556,6 +7568,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7860,6 +7873,7 @@
       "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8765,6 +8779,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8984,6 +8999,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9174,6 +9190,7 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9321,6 +9338,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9426,6 +9444,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
         "@vue/compiler-sfc": "3.5.22",
@@ -9455,6 +9474,7 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -9909,6 +9929,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10009,6 +10030,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/frontend/app/src/components/Settings/SettingsUserProfileZone.vue
+++ b/frontend/app/src/components/Settings/SettingsUserProfileZone.vue
@@ -142,6 +142,15 @@
             </span>
             <span v-else>{{ $t('generalItems.labelNotApplicable') }}</span>
           </p>
+          <!-- user max heart rate -->
+          <p>
+            <font-awesome-icon :icon="['fas', 'heart-pulse']" class="me-2" />
+            <b>{{ $t('settingsUserProfileZone.maxHeartRateLabel') }}: </b>
+            <span v-if="authStore.user.max_heart_rate"
+              >{{ authStore.user.max_heart_rate }} {{ $t('generalItems.unitsBpm') }}</span
+            >
+            <span v-else>{{ $t('generalItems.labelNotApplicable') }}</span>
+          </p>
           <!-- user preferred language -->
           <p>
             <font-awesome-icon :icon="['fas', 'language']" class="me-2" />

--- a/frontend/app/src/components/Settings/SettingsUsersZone/UsersAddEditUserModalComponent.vue
+++ b/frontend/app/src/components/Settings/SettingsUsersZone/UsersAddEditUserModalComponent.vue
@@ -310,6 +310,27 @@
                 </div>
               </div>
             </div>
+            <!-- max heart rate fields -->
+            <label for="userMaxHeartRateAddEdit"
+              ><b>{{
+                $t('usersAddEditUserModalComponent.addEditUserModalMaxHeartRateLabel')
+              }}</b></label
+            >
+            <div class="input-group">
+              <input
+                class="form-control"
+                type="number"
+                name="userMaxHeartRateAddEdit"
+                :placeholder="
+                  $t('usersAddEditUserModalComponent.addEditUserModalMaxHeartRatePlaceholder')
+                "
+                v-model="newEditUserMaxHeartRate"
+                min="100"
+                max="250"
+                step="1"
+              />
+              <span class="input-group-text">{{ $t('generalItems.unitsBpm') }}</span>
+            </div>
             <!-- preferred language fields -->
             <label for="userPreferredLanguageAddEdit"
               ><b
@@ -495,6 +516,7 @@ const newEditUserCurrency = ref(serverSettingsStore.serverSettings.currency)
 const newEditUserHeightCms = ref(null)
 const newEditUserHeightFeet = ref(null)
 const newEditUserHeightInches = ref(null)
+const newEditUserMaxHeartRate = ref(null)
 const newEditUserFirstDayOfWeek = ref(1)
 const isFeetValid = computed(
   () => newEditUserHeightFeet.value >= 0 && newEditUserHeightFeet.value <= 10
@@ -538,6 +560,7 @@ if (props.user) {
   newEditUserUnits.value = props.user.units
   newEditUserCurrency.value = props.user.currency
   newEditUserHeightCms.value = props.user.height
+  newEditUserMaxHeartRate.value = props.user.max_heart_rate
   newEditUserPreferredLanguage.value = props.user.preferred_language
   newEditUserFirstDayOfWeek.value = props.user.first_day_of_week
   newEditUserAccessType.value = props.user.access_type
@@ -646,6 +669,7 @@ async function submitAddUserForm() {
         units: newEditUserUnits.value,
         currency: newEditUserCurrency.value,
         height: newEditUserHeightCms.value,
+        max_heart_rate: newEditUserMaxHeartRate.value,
         access_type: newEditUserAccessType.value,
         photo_path: null,
         first_day_of_week: newEditUserFirstDayOfWeek.value,
@@ -689,6 +713,7 @@ async function submitEditUserForm() {
       units: newEditUserUnits.value,
       currency: newEditUserCurrency.value,
       height: newEditUserHeightCms.value,
+      max_heart_rate: newEditUserMaxHeartRate.value,
       preferred_language: newEditUserPreferredLanguage.value,
       first_day_of_week: newEditUserFirstDayOfWeek.value,
       access_type: newEditUserAccessType.value,

--- a/frontend/app/src/i18n/de/components/settings/settingsUserProfileZoneComponent.json
+++ b/frontend/app/src/i18n/de/components/settings/settingsUserProfileZoneComponent.json
@@ -16,6 +16,7 @@
   "unitsOption2": "Imperial",
   "currencyLabel": "Währung",
   "heightLabel": "Höhe",
+  "maxHeartRateLabel": "Maximale Herzfrequenz",
   "preferredLanguageLabel": "Bevorzugte Sprache",
   "firstDayOfWeekLabel": "Erster Tag der Woche",
   "accessTypeLabel": "Zugangsart",

--- a/frontend/app/src/i18n/de/components/settings/settingsUsersZone/usersAddEditUserModalComponent.json
+++ b/frontend/app/src/i18n/de/components/settings/settingsUsersZone/usersAddEditUserModalComponent.json
@@ -26,6 +26,8 @@
   "addEditUserModalCurrencyLabel": "Währung",
   "addEditUserModalHeightLabel": "Größe",
   "addEditUserModalHeightPlaceholder": "Größe",
+  "addEditUserModalMaxHeartRateLabel": "Maximale Herzfrequenz (optional)",
+  "addEditUserModalMaxHeartRatePlaceholder": "Maximale Herzfrequenz",
   "addEditUserModalFeetValidationLabel": "Ungültige Höhe. Bitte geben Sie eine gültige Höhe in Fuß ein.",
   "addEditUserModalInchesValidationLabel": "Ungültige Höhe. Bitte geben Sie eine gültige Höhe in Zoll ein.",
   "addEditUserModalUserPreferredLanguageLabel": "Bevorzugte Sprache",

--- a/frontend/app/src/i18n/us/components/settings/settingsUserProfileZoneComponent.json
+++ b/frontend/app/src/i18n/us/components/settings/settingsUserProfileZoneComponent.json
@@ -16,6 +16,7 @@
   "unitsOption2": "Imperial",
   "currencyLabel": "Currency",
   "heightLabel": "Height",
+  "maxHeartRateLabel": "Max heart rate",
   "preferredLanguageLabel": "Preferred language",
   "firstDayOfWeekLabel": "First day of week",
   "accessTypeLabel": "Access type",

--- a/frontend/app/src/i18n/us/components/settings/settingsUsersZone/usersAddEditUserModalComponent.json
+++ b/frontend/app/src/i18n/us/components/settings/settingsUsersZone/usersAddEditUserModalComponent.json
@@ -26,6 +26,8 @@
   "addEditUserModalCurrencyLabel": "Currency",
   "addEditUserModalHeightLabel": "Height",
   "addEditUserModalHeightPlaceholder": "Height",
+  "addEditUserModalMaxHeartRateLabel": "Max heart rate (optional)",
+  "addEditUserModalMaxHeartRatePlaceholder": "Max heart rate",
   "addEditUserModalFeetValidationLabel": "Invalid height. Please enter a valid height in feet.",
   "addEditUserModalInchesValidationLabel": "Invalid height. Please enter a valid height in inches.",
   "addEditUserModalUserPreferredLanguageLabel": "Preferred language",


### PR DESCRIPTION
Add optional max_heart_rate field to user profile to allow users to override the age-based maximum heart rate calculation (220 - age).

Backend changes:
- Add max_heart_rate column to users table (nullable Integer)
- Update User model and schema to include max_heart_rate
- Create Alembic migration v0.16.0 to add the new column
- Modify heart rate zone calculation to use user's max_heart_rate if set, otherwise fallback to age-based formula

Frontend changes:
- Add max heart rate input field to user profile edit modal
- Display max heart rate in user profile view
- Add translations for US English and German locales
- Update UsersAddEditUserModalComponent to handle max_heart_rate

This allows users to provide a more accurate maximum heart rate based on actual testing rather than relying solely on the age-based estimation, resulting in more accurate heart rate zone calculations (zones 1-5) in activity analysis.