### PR TITLE
Fix pace calculation for lap swimming activities without splits

### DIFF
--- a/backend/app/fit/utils.py
+++ b/backend/app/fit/utils.py
@@ -1087,7 +1087,7 @@ def append_if_not_none(waypoint_list, time, value, key):
 
 def calculate_pace(distance, total_timer_time, activity_type, split_summary):
     if distance:
-        if activity_type != "lap_swimming":
+        if activity_type != "lap_swimming" or not split_summary:
             return total_timer_time, total_timer_time / distance
         time_active = 0
         for split in split_summary:


### PR DESCRIPTION
I understand that FIT parsing of lap swimming activities was written for a specifically formatted FIT file, that contains split messages. However, split messages don't seem to be required by the standard (not that there's a clear indication of what's required and what's optional, mind you... This standard is a mess).

I am in the middle of writing a "data liberation" tool that converts Samsung Health data to FIT files that I'd like to import into Endurain, and the FIT files I generate from swimming activities do not contain split messages (I followed the recommendations on Garmin's FIT SDK website, and included lap and length messages). In fact, even if I wanted to add split messages, I can't do that - since the library I'm using [fit-tool](https://pypi.org/project/fit-tool/) does not support it.

So I propose this change, where lap swimming activities without explicitly provided split summary will have their pace calculated the same as other activities - i.e., total timer divided by total distance, under the assumption that the whole activity consists of active splits. I understand that this is not a comprehensive solution (that would entail developing support for length messages and choosing between using lengths or splits), but it's quick, it serves its purpose, and it's backward-compatible (so lap swimming activities that do include split data will continue working as before).