### PR TITLE
fix: add missing mapping for eBike rides

### DIFF
--- a/backend/app/fit/utils.py
+++ b/backend/app/fit/utils.py
@@ -793,6 +793,8 @@ def parse_frame_session(frame):
             activity_type = "commuting_ride"
         elif activity_type == "cycling" and sub_sport == "indoor_cycling":
             activity_type = "indoor_ride"
+        elif activity_type == "cycling" and sub_sport == "e_bike_fitness":
+            activity_type = "ebikeride"
         elif activity_type == "cycling" and sub_sport == "mixed_surface":
             activity_type = "mixed_surface_ride"
         elif activity_type == 64 and sub_sport == 85:


### PR DESCRIPTION
Currently importing E-Bike rides from Garmin are resulting in "Workout" activities. This PR add the missing mapping.

Resolves #458 