### PR TITLE
Fix .env comments preventing startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,24 +2,34 @@
 # These are just the variable you have to set to be up and running.
 # There is many more variable you could set. Check them out here: https://docs.endurain.com/getting-started/advanced-started/#supported-environment-variables
 
-DB_PASSWORD=changeme # Set a strong password here. Check if there are no trailing whitespaces in the beginning and end. Must be the same as POSTGRES_PASSWORD
-POSTGRES_PASSWORD=changeme # Must be the same as DB_PASSWORD
+# Set a strong password here. Check if there are no trailing whitespaces in the beginning and end. Must be the same as POSTGRES_PASSWORD
+DB_PASSWORD=changeme
+# Must be the same as DB_PASSWORD
+POSTGRES_PASSWORD=changeme
 SECRET_KEY=changeme
 FERNET_KEY=changeme
 TZ=Europe/Lisbon
 ENDURAIN_HOST=https://endurain.example.com
 BEHIND_PROXY=true
-POSTGRES_DB=endurain # If you change this, you also have to change DB_DATABASE
-# DB_DATABASE=endurain # Uncomment and set it to the same as POSTGRES_DB if you change it
-POSTGRES_USER=endurain # If you change this, you also have to change DB_USER
-# DB_USER=endurain # Uncomment and set it to the same as POSTGRES_USER if you change it
+
+# If you change this, you also have to change DB_DATABASE
+POSTGRES_DB=endurain
+# Uncomment and set it to the same as POSTGRES_DB if you change it
+# DB_DATABASE=endurain
+# If you change this, you also have to change DB_USER
+POSTGRES_USER=endurain
+# Uncomment and set it to the same as POSTGRES_USER if you change it
+# DB_USER=endurain
 PGDATA=/var/lib/postgresql/data/pgdata
 
 # Optional: Enable session timeouts (default: false)
-#SESSION_IDLE_TIMEOUT_ENABLED=true    # Enable idle session timeout
+# Enable idle session timeout
+#SESSION_IDLE_TIMEOUT_ENABLED=true
 # If enabled, configure timeout durations
-#SESSION_IDLE_TIMEOUT_HOURS=1        # Idle timeout (no activity)
-#SESSION_ABSOLUTE_TIMEOUT_HOURS=24   # Absolute max session lifetime
+# Idle timeout (no activity)
+#SESSION_IDLE_TIMEOUT_HOURS=1
+# Absolute max session lifetime
+#SESSION_ABSOLUTE_TIMEOUT_HOURS=24
 
 # Email configuration (for password reset functionality)
 #SMTP_HOST=smtp.protonmail.ch


### PR DESCRIPTION
Comments are included in the variable, this can be observe in the logs of the database:

```
endurain-db | server started
endurain-db | NOTICE:  identifier "endurain # If you change this, you also have to change DB_DATABASE" will be truncated to "endurain # If you change this, you also have to change DB_DATAB"
endurain-db | CREATE DATABASE
[.../...]
endurain-db | 2026-01-20 07:48:48.478 EST [74] FATAL:  password authentication failed for user "endurain"
endurain-db | 2026-01-20 07:48:48.478 EST [74] DETAIL:  Role "endurain" does not exist.
```

Driving the app to crash:

```
endurain-app | sqlalchemy.exc.OperationalError: (psycopg.OperationalError) connection failed: connection to server at "192.168.240.2", port 5432 failed: FATAL:  password authentication failed for user "endurain"
endurain-app | (Background on this error at: https://sqlalche.me/e/20/e3q8)
endurain-app |
endurain-app | ERROR:    Application startup failed. Exiting.
``` 

Moving comments to dedicated lines allows the app to start smoothly.