### PR TITLE
Define BACKEND_DIR env var for entrypoint script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,7 +61,8 @@ RUN set -eux; \
 # Define environment variables
 ENV UID=1000 \
     GID=1000 \
-    BEHIND_PROXY=false
+    BEHIND_PROXY=false \
+    BACKEND_DIR=/app/backend
 
 # Set the working directory to /app/frontend
 WORKDIR /app/frontend


### PR DESCRIPTION
This is related to #489.

The fix you provided works in principle, but in order for it to work, one has to (explicitly) set the `BACKEND_DIR` environment variable (because this is not available by the time the entrypoint script runs).

This is consistent with how the default value for the environment variable is defined at runtime
https://github.com/endurain-project/endurain/blob/35e172d4604ad1035655a94cfe12ceeda012bcd4/backend/app/core/config.py#L18