### PR TITLE
Turn invalid FERNET KEY into an err to stop app

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -307,6 +307,9 @@ def check_required_env_vars():
                 "FERNET_KEY validation failed. Please check the key format and regenerate if necessary.",
                 "warning",
             )
+            raise ValueError(
+                "FERNET_KEY validation failed. Please check the key format and regenerate if necessary."
+            )
 
     validate_log_level(LOG_LEVEL)
 


### PR DESCRIPTION
PR addresses issue #517 where the app crashes with a 500 error when linking Strava if the encryption key is invalid.

**Problem:** Currently, `validate_fernet_key` logs a warning for a bad key but still allows the application to start. This leaves the app in a broken state, causing the reported crash later when the key is actually used for encryption.

**Fix:** I updated the validation logic in config.py to fail fast.
If FERNET_KEY is missing, default (changeme), or invalid base64, the app now raises a ValueError and refuses to start.
This prevents the runtime crash entirely and gives the admin immediate feedback to fix their .env file.

**Testing**:  Verified locally that the app exits immediately with a clear error message if FERNET_KEY=changeme.
Verified that the app starts normally with a valid key.