### PR TITLE
feat: Add alt text to activity icons

### DIFF
--- a/frontend/app/src/components/Activities/ActivitiesTableRowComponent.vue
+++ b/frontend/app/src/components/Activities/ActivitiesTableRowComponent.vue
@@ -1,6 +1,12 @@
 <template>
   <td>
-    <font-awesome-icon :icon="getIcon(activity.activity_type)" />
+    <span
+      role="img"
+      :title="activityTypeName(activity.activity_type, t)"
+      :aria-label="activityTypeName(activity.activity_type, t)"
+    >
+      <font-awesome-icon :icon="getIcon(activity.activity_type)" aria-hidden="true" />
+    </span>
   </td>
   <td>
     <router-link
@@ -54,6 +60,7 @@ import {
   formatHr,
   formatCalories,
   getIcon,
+  activityTypeName,
   formatLocation,
   formatAverageSpeed,
   activityTypeIsWalking,

--- a/frontend/app/src/components/Activities/ActivitiesTypeBreakdownTableComponent.vue
+++ b/frontend/app/src/components/Activities/ActivitiesTypeBreakdownTableComponent.vue
@@ -16,7 +16,15 @@
       </thead>
       <tbody>
         <tr v-for="item in typeBreakdownData" :key="item.activity_type_id">
-          <td><font-awesome-icon :icon="getIcon(item.activity_type_id)" /></td>
+          <td>
+            <span
+              role="img"
+              :title="activityTypeName(item.activity_type_id, t)"
+              :aria-label="activityTypeName(item.activity_type_id, t)"
+            >
+              <font-awesome-icon :icon="getIcon(item.activity_type_id)" aria-hidden="true" />
+            </span>
+          </td>
           <td>{{ formatRawDistance(t, item.total_distance, authStore.user.units) }}</td>
           <td>{{ formatDuration(t, item.total_duration) }}</td>
           <td class="d-none d-sm-table-cell">
@@ -37,6 +45,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import NoItemsFoundComponents from '@/components/GeneralComponents/NoItemsFoundComponents.vue'
 import {
   getIcon,
+  activityTypeName,
   formatRawDistance,
   formatDuration,
   formatElevation,

--- a/frontend/app/src/components/Activities/ActivitySummaryComponent.vue
+++ b/frontend/app/src/components/Activities/ActivitySummaryComponent.vue
@@ -39,7 +39,13 @@
 
             <!-- Display the activity type -->
             <span>
-              <font-awesome-icon class="me-1" :icon="getIcon(activity.activity_type)" />
+              <span
+                role="img"
+                :title="activityTypeName(activity.activity_type, t)"
+                :aria-label="activityTypeName(activity.activity_type, t)"
+              >
+                <font-awesome-icon class="me-1" :icon="getIcon(activity.activity_type)" aria-hidden="true" />
+              </span>
               <span v-if="activity.activity_type === 3 || activity.activity_type === 7">{{
                 $t('activitySummaryComponent.labelVirtual')
               }}</span>
@@ -371,6 +377,7 @@ import {
   formatHr,
   formatCalories,
   getIcon,
+  activityTypeName,
   formatLocation,
   formatAverageSpeed,
   formatPower,

--- a/frontend/app/src/views/SearchView.vue
+++ b/frontend/app/src/views/SearchView.vue
@@ -88,11 +88,18 @@
             <!-- icon for user -->
             <font-awesome-icon :icon="['fas', 'user']" v-if="searchSelectValue == 1" />
             <!-- icons for activities -->
-            <font-awesome-icon
-              class="ms-1"
-              :icon="getIcon(result.activity_type)"
+            <span
+              role="img"
+              :title="activityTypeName(result.activity_type, t)"
+              :aria-label="activityTypeName(result.activity_type, t)"
               v-if="searchSelectValue == 2"
-            />
+            >
+              <font-awesome-icon
+                class="ms-1"
+                :icon="getIcon(result.activity_type)"
+                aria-hidden="true"
+              />
+            </span>
             <!-- icons for gears -->
             <font-awesome-icon
               :icon="['fas', 'bicycle']"
@@ -191,7 +198,7 @@ import { users } from '@/services/usersService'
 import { gears } from '@/services/gearsService'
 import { activities } from '@/services/activitiesService'
 import { formatDateMed } from '@/utils/dateTimeUtils'
-import { getIcon } from '@/utils/activityUtils'
+import { getIcon, activityTypeName } from '@/utils/activityUtils'
 // import components
 import LoadingComponent from '@/components/GeneralComponents/LoadingComponent.vue'
 import NoItemsFoundComponents from '@/components/GeneralComponents/NoItemsFoundComponents.vue'


### PR DESCRIPTION
## Summary

Adds a native browser tooltip to activity type icons, displaying the localized activity type name (e.g. "Gravel", "MTB", "Virtual ride"...) when hovering over the icon.

## Changes

- Wrapped `<font-awesome-icon>` elements in a `<span title="...">` in all 4 locations where activity type icons are rendered:
  - Activities list table (`ActivitiesTableRowComponent.vue`)
  - Activity detail page header (`ActivitySummaryComponent.vue`)
  - Type breakdown stats table (`ActivitiesTypeBreakdownTableComponent.vue`)
  - Search results (`SearchView.vue`)
- Used the existing `activityTypeName()` utility with i18n support — tooltips are fully localized.

## Why `<span title>` instead of Font Awesome's `:title` prop

Font Awesome renders icons as `<svg>` elements. The `:title` prop injects a `<title>` tag inside the SVG, which browsers (notably Chrome/Edge) do not consistently display as a hover tooltip. Wrapping with a `<span title="...">` is the standard cross-browser approach.

## Testing

Hover over any activity type icon in:
- The activities list
- An activity detail page
- The stats breakdown table ("Répartition par type")
- The search results